### PR TITLE
Add EmptyCardSlot entity

### DIFF
--- a/src/components/arena/EnergyZone.vue
+++ b/src/components/arena/EnergyZone.vue
@@ -14,8 +14,8 @@
 import type { Energy } from "@/core";
 
 export interface Props {
-  currentEnergy: Energy | null;
-  nextEnergy: Energy | null;
+  currentEnergy: Energy | undefined;
+  nextEnergy: Energy | undefined;
 }
 defineProps<Props>();
 </script>

--- a/src/components/arena/InPlayCardSlot.vue
+++ b/src/components/arena/InPlayCardSlot.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="card" class="stacked" :style="cardStyle">
+  <div v-if="card?.isPokemon" class="stacked" :style="cardStyle">
     <PlayingCard :card="card.BaseCard" :height-px="heightPx" />
 
     <div class="card-hp d-flex flex-column align-end">
@@ -29,12 +29,12 @@
 <script setup lang="ts">
 import EnergyIcon from "@/components/common/EnergyIcon.vue";
 import PlayingCard from "@/components/common/PlayingCard.vue";
-import type { InPlayPokemonCard } from "@/core/gamelogic/InPlayPokemonCard";
+import type { EmptyCardSlot, InPlayPokemonCard } from "@/core";
 import { computed } from "vue";
 
 export interface Props {
   heightPx?: number;
-  card?: InPlayPokemonCard;
+  card?: InPlayPokemonCard | EmptyCardSlot;
 }
 const props = defineProps<Props>();
 

--- a/src/components/arena/PlayingField.vue
+++ b/src/components/arena/PlayingField.vue
@@ -7,22 +7,22 @@
             <InPlayCardSlot
               v-for="i in 3"
               :key="i"
-              :card="game?.Player2.Bench[i - 1]"
+              :card="game?.Player2.Bench[i - 1] ?? EmptyCardSlot.Bench(i - 1)"
               :height-px="140"
             />
           </v-row>
           <v-row no-gutters class="align-center">
-            <InPlayCardSlot :card="game?.Player2.ActivePokemon" />
+            <InPlayCardSlot :card="game?.Player2.ActivePokemon ?? EmptyCardSlot.Active()" />
           </v-row>
 
           <v-row no-gutters class="align-center">
-            <InPlayCardSlot :card="game?.Player1.ActivePokemon" />
+            <InPlayCardSlot :card="game?.Player1.ActivePokemon ?? EmptyCardSlot.Active()" />
           </v-row>
           <v-row no-gutters class="align-center ga-1">
             <InPlayCardSlot
               v-for="i in 3"
               :key="i"
-              :card="game?.Player1.Bench[i - 1]"
+              :card="game?.Player1.Bench[i - 1] ?? EmptyCardSlot.Bench(i - 1)"
               :height-px="140"
             />
           </v-row>
@@ -65,9 +65,15 @@
 
 <script setup lang="ts">
 import type { Game } from "@/core";
+import { EmptyCardSlot } from "@/core/gamelogic/types/EmptyCardSlot";
+import EnergyZone from "./EnergyZone.vue";
+import GameLog from "./GameLog.vue";
+import InPlayCardSlot from "./InPlayCardSlot.vue";
+import PlayerHandHidden from "./PlayerHandHidden.vue";
+import PlayerHandVisible from "./PlayerHandVisible.vue";
 
 export interface Props {
-  game: Game | null;
+  game: Game | undefined;
   shownPlayers?: string[];
 }
 defineProps<Props>();

--- a/src/components/common/CardName.vue
+++ b/src/components/common/CardName.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script setup lang="ts">
-import { usePlayingCardStore } from "@/stores/usePlayingCardStore";
+import { usePlayingCardStore } from "@/stores";
 import { computed } from "vue";
 
 export interface Props {

--- a/src/core/agents/BetterRandomAgent.ts
+++ b/src/core/agents/BetterRandomAgent.ts
@@ -68,9 +68,9 @@ export class BetterRandomAgent extends PlayerAgent {
     if (game.canRetreat()) {
       if (
         game.retreatCostModifier < 0
-          ? (game.selfActive!.RetreatCost ?? 0) + game.retreatCostModifier <= 0 ||
+          ? (game.selfActive.RetreatCost ?? 0) + game.retreatCostModifier <= 0 ||
             Math.random() < 0.5
-          : Math.random() < Math.pow(0.5, (game.selfActive!.RetreatCost ?? 0) + 2)
+          : Math.random() < Math.pow(0.5, (game.selfActive.RetreatCost ?? 0) + 2)
       ) {
         const randomBench = rand(game.selfBenched);
         await game.retreatActivePokemon(randomBench);

--- a/src/core/agents/BetterRandomAgent.ts
+++ b/src/core/agents/BetterRandomAgent.ts
@@ -50,7 +50,7 @@ export class BetterRandomAgent extends PlayerAgent {
     ) as PokemonCard[];
     const bench = game.selfBench;
     for (let i = 0; i < 3 && handBasics.length > 0; i++) {
-      if (bench[i] == undefined) {
+      if (!bench[i].isPokemon) {
         const randomBasic = rand(handBasics);
         await game.playPokemonToBench(randomBasic, i);
         handBasics.splice(handBasics.indexOf(randomBasic), 1);

--- a/src/core/agents/BetterRandomAgent.ts
+++ b/src/core/agents/BetterRandomAgent.ts
@@ -21,7 +21,7 @@ export class BetterRandomAgent extends PlayerAgent {
   }
 
   async doTurn(game: PlayerGameView) {
-    let ownPokemon = [game.selfActive, ...game.selfBenched].filter((x) => x !== undefined);
+    let ownPokemon = game.selfInPlayPokemon;
 
     // Play Professor's Research if available
     const professor = game.selfHand.find((x) => x.Name == "Professor's Research");
@@ -94,7 +94,7 @@ export class BetterRandomAgent extends PlayerAgent {
       await game.playPokemonToEvolve(randomEvolver, randomEvolvee);
     }
 
-    ownPokemon = [game.selfActive, ...game.selfBenched].filter((x) => x !== undefined);
+    ownPokemon = game.selfInPlayPokemon;
 
     // If any Pokemon has a usable Ability, use it
     const pokemonWithAbilities = ownPokemon.filter(
@@ -104,16 +104,19 @@ export class BetterRandomAgent extends PlayerAgent {
       await game.useAbility(pokemon, pokemon.Ability!);
     }
 
+    const active = game.selfActive;
+    if (!active.isPokemon) return;
+
     // Play energy
     if (
-      game.selfActive!.Attacks.some((a) =>
-        this.findRemainingEnergy(game.selfActive!, a.RequiredEnergy).some(
+      active.Attacks.some((a) =>
+        this.findRemainingEnergy(active, a.RequiredEnergy).some(
           (e) => e == game.selfAvailableEnergy || e == "Colorless"
         )
       )
     ) {
       // If the active Pokemon needs the available energy for any attack, attach it
-      await game.attachAvailableEnergy(game.selfActive!);
+      await game.attachAvailableEnergy(active);
     } else {
       // Otherwise, check the energy needs of all Pokemon on the field and their evolutions
       const pokemonEnergyRequirements = ownPokemon.map((p) => {
@@ -143,7 +146,7 @@ export class BetterRandomAgent extends PlayerAgent {
         // This way we don't waste energy on Pokemon that will be able to attack on the turn they switch in
         if (pokemonNeedingExtraEnergy.some((x) => x.pokemon == game.selfActive)) {
           // If the active Pokemon needs extra energy, attach to it first
-          await game.attachAvailableEnergy(game.selfActive!);
+          await game.attachAvailableEnergy(active);
         } else {
           const randomPokemon = rand(pokemonNeedingExtraEnergy).pokemon;
           await game.attachAvailableEnergy(randomPokemon);
@@ -154,13 +157,13 @@ export class BetterRandomAgent extends PlayerAgent {
         await game.attachAvailableEnergy(randomPokemon);
       } else {
         // If no Pokemon need energy, attach to the active Pokemon
-        await game.attachAvailableEnergy(game.selfActive!);
+        await game.attachAvailableEnergy(active);
       }
     }
 
     // End turn with a random attack
     const attacks = [];
-    for (const attack of game.selfActive?.Attacks ?? []) {
+    for (const attack of active.Attacks ?? []) {
       if (game.canUseAttack(attack)) attacks.push(attack);
     }
     if (attacks.length > 0) {

--- a/src/core/agents/RandomAgent.ts
+++ b/src/core/agents/RandomAgent.ts
@@ -24,7 +24,7 @@ export class RandomAgent extends PlayerAgent {
   }
 
   async doTurn(game: PlayerGameView) {
-    const ownPokemon = [game.selfActive, ...game.selfBenched].filter((x) => x !== undefined);
+    const ownPokemon = game.selfInPlayPokemon;
 
     // Attach energy to random Pokemon if available
     if (game.selfAvailableEnergy) {
@@ -92,9 +92,12 @@ export class RandomAgent extends PlayerAgent {
       await game.playPokemonToEvolve(randomEvolver, randomEvolvee);
     }
 
+    const active = game.selfActive;
+    if (!active.isPokemon) return;
+
     // End turn with a random attack
     const attacks = [];
-    for (const attack of game.selfActive?.Attacks ?? []) {
+    for (const attack of active.Attacks ?? []) {
       if (game.canUseAttack(attack)) attacks.push(attack);
     }
     if (attacks.length > 0) {

--- a/src/core/agents/RandomAgent.ts
+++ b/src/core/agents/RandomAgent.ts
@@ -66,7 +66,7 @@ export class RandomAgent extends PlayerAgent {
     if (game.canRetreat()) {
       if (
         game.retreatCostModifier < 0
-          ? (game.selfActive!.RetreatCost ?? 0) + game.retreatCostModifier <= 0 ||
+          ? (game.selfActive.RetreatCost ?? 0) + game.retreatCostModifier <= 0 ||
             Math.random() < 0.5
           : Math.random() < 0.125
       ) {

--- a/src/core/agents/RandomAgent.ts
+++ b/src/core/agents/RandomAgent.ts
@@ -39,7 +39,7 @@ export class RandomAgent extends PlayerAgent {
       const randomBasic = rand(handBasics);
       const bench = game.selfBench;
       for (let i = 0; i < 3; i++) {
-        if (bench[i] == undefined) {
+        if (!bench[i].isPokemon) {
           await game.playPokemonToBench(randomBasic, i);
           break;
         }

--- a/src/core/gamelogic/Game.ts
+++ b/src/core/gamelogic/Game.ts
@@ -341,10 +341,10 @@ export class Game {
 
     // Have players choose a new Active Pokemon if their previous one was knocked out
     const promises = [];
-    if (this.Player1.ActivePokemon === undefined) {
+    if (!this.Player1.ActivePokemon.isPokemon) {
       promises[0] = this.Agent1.swapActivePokemon(new PlayerGameView(this, this.Player1));
     }
-    if (this.Player2.ActivePokemon === undefined) {
+    if (!this.Player2.ActivePokemon.isPokemon) {
       promises[1] = this.Agent2.swapActivePokemon(new PlayerGameView(this, this.Player2));
     }
     if (promises.length > 0) {

--- a/src/core/gamelogic/Game.ts
+++ b/src/core/gamelogic/Game.ts
@@ -167,7 +167,7 @@ export class Game {
     }
 
     // Log the Special Conditions that will affect the Active Pokemon
-    const status = this.AttackingPlayer.ActivePokemon!.PrimaryCondition;
+    const status = this.AttackingPlayer.activeOrThrow().PrimaryCondition;
     if (status == "Asleep" || status == "Paralyzed") {
       this.GameLog.specialConditionEffective(this.AttackingPlayer);
     }
@@ -210,7 +210,7 @@ export class Game {
 
     const attacker = this.AttackingPlayer.ActivePokemon;
     const defender = this.DefendingPlayer.ActivePokemon;
-    if (attacker == undefined || defender == undefined) {
+    if (!attacker.isPokemon || !defender.isPokemon) {
       this.GameLog.invalidGameState();
       this.GameOver = true;
       return;
@@ -439,12 +439,12 @@ export class Game {
   }
 
   attackActivePokemon(HP: number) {
-    const defender = this.DefendingPlayer.ActivePokemon!;
+    const defender = this.DefendingPlayer.activeOrThrow();
     return this.attackPokemon(defender, HP);
   }
 
   attackPokemon(defender: InPlayPokemonCard, HP: number) {
-    const attacker = this.AttackingPlayer.ActivePokemon!;
+    const attacker = this.AttackingPlayer.activeOrThrow();
     const type = attacker.Type;
     const initialHP = defender.CurrentHP;
     const owner = this.DefendingPlayer;

--- a/src/core/gamelogic/InPlayPokemonCard.ts
+++ b/src/core/gamelogic/InPlayPokemonCard.ts
@@ -29,6 +29,8 @@ export class InPlayPokemonCard {
   InPlayCards: PlayingCard[] = [];
   ReadyToEvolve: boolean = false;
 
+  isPokemon = true as const;
+
   constructor(inputCard: PokemonCard) {
     this.BaseCard = inputCard;
     this.InPlayCards.push(inputCard);

--- a/src/core/gamelogic/Player.ts
+++ b/src/core/gamelogic/Player.ts
@@ -22,8 +22,8 @@ export class Player {
   DiscardedEnergy: Energy[] = []; // Energy that has been discarded during the game
   GamePoints: number = 0; // The number of prize cards the player has taken (for winning the game)
 
-  ActivePokemon: InPlayPokemonCard | EmptyCardSlot; // The active Pokémon card (undefined only for setup phase)
-  Bench: (InPlayPokemonCard | EmptyCardSlot)[]; // Pokémon cards on the bench, undefined if no Pokémon is in a slot
+  ActivePokemon: InPlayPokemonCard | EmptyCardSlot; // The active Pokémon card (EmptyCardSlot during setup phase and when active is knocked out)
+  Bench: (InPlayPokemonCard | EmptyCardSlot)[]; // Pokémon cards on the bench, EmptyCardSlot if no Pokémon is in a slot
   AvailableEnergy?: Energy; // The energy type available for use this turn, if any (not used in all game modes)
   NextEnergy: Energy = "Colorless"; // The next energy type to be used for attaching to Pokémon, set when the game starts
 

--- a/src/core/gamelogic/Player.ts
+++ b/src/core/gamelogic/Player.ts
@@ -8,6 +8,7 @@ import type { Deck, Energy, PlayingCard, PokemonCard } from "../types";
 import { CoinFlipper } from "./CoinFlipper";
 import type { Game } from "./Game";
 import { InPlayPokemonCard } from "./InPlayPokemonCard";
+import { EmptyCardSlot } from "./types/EmptyCardSlot";
 import type { PlayerGameSetup } from "./types/PlayerAgent";
 import type { PokemonStatus } from "./types/Status";
 
@@ -21,8 +22,8 @@ export class Player {
   DiscardedEnergy: Energy[] = []; // Energy that has been discarded during the game
   GamePoints: number = 0; // The number of prize cards the player has taken (for winning the game)
 
-  ActivePokemon?: InPlayPokemonCard; // The active Pokémon card (undefined only for setup phase)
-  Bench: (InPlayPokemonCard | undefined)[] = []; // Pokémon cards on the bench, undefined if no Pokémon is in a slot
+  ActivePokemon: InPlayPokemonCard | EmptyCardSlot; // The active Pokémon card (undefined only for setup phase)
+  Bench: (InPlayPokemonCard | EmptyCardSlot)[]; // Pokémon cards on the bench, undefined if no Pokémon is in a slot
   AvailableEnergy?: Energy; // The energy type available for use this turn, if any (not used in all game modes)
   NextEnergy: Energy = "Colorless"; // The next energy type to be used for attaching to Pokémon, set when the game starts
 
@@ -31,10 +32,10 @@ export class Player {
   private flipper: CoinFlipper;
 
   get InPlayPokemon() {
-    return [this.ActivePokemon, ...this.Bench].filter((x) => x !== undefined);
+    return [this.ActivePokemon, ...this.Bench].filter((x) => x.isPokemon);
   }
   get BenchedPokemon() {
-    return this.Bench.filter((x) => x !== undefined);
+    return this.Bench.filter((x) => x.isPokemon);
   }
 
   constructor(name: string, deck: Deck, game: Game) {
@@ -44,6 +45,12 @@ export class Player {
     this.game = game;
     this.logger = game.GameLog;
     this.flipper = new CoinFlipper(this);
+
+    this.ActivePokemon = EmptyCardSlot.Active();
+    this.Bench = [];
+    for (let i = 0; i < 3; i++) {
+      this.Bench.push(EmptyCardSlot.Bench(i));
+    }
   }
 
   pokemonToDescriptor(pokemon: InPlayPokemonCard): InPlayPokemonDescriptor {
@@ -69,8 +76,11 @@ export class Player {
   }
 
   reset() {
-    this.ActivePokemon = undefined;
+    this.ActivePokemon = EmptyCardSlot.Active();
     this.Bench = [];
+    for (let i = 0; i < 3; i++) {
+      this.Bench.push(EmptyCardSlot.Bench(i));
+    }
 
     this.Deck = this.Deck.concat(this.Hand, this.InPlay, this.Discard);
     this.Hand = [];
@@ -203,13 +213,14 @@ export class Player {
       throw new Error("Pokemon not on bench");
     }
     this.ActivePokemon = pokemon;
-    this.Bench[this.Bench.indexOf(pokemon)] = undefined;
+    const index = this.Bench.indexOf(pokemon);
+    this.Bench[index] = EmptyCardSlot.Bench(index);
 
     this.logger.selectActivePokemon(this);
   }
 
   async putPokemonOnBench(card: PokemonCard, index: number, trueCard: PlayingCard = card) {
-    if (this.Bench[index]) {
+    if (this.Bench[index].isPokemon) {
       throw new Error("Bench already has a Pokemon in this slot");
     }
     if (card.Stage != 0) {
@@ -315,24 +326,31 @@ export class Player {
     this.logger.discardEnergy(this, energies, source);
   }
 
+  activeOrThrow(): InPlayPokemonCard {
+    if (!this.ActivePokemon.isPokemon) {
+      throw new Error("No active Pokemon");
+    }
+    return this.ActivePokemon;
+  }
+
   retreatActivePokemon(
-    benchedPokemon: InPlayPokemonCard,
+    newActive: InPlayPokemonCard,
     energyToDiscard: Energy[],
     costModifier: number
   ) {
-    const previousActive = this.ActivePokemon!;
-    if (previousActive.RetreatCost == -1) {
+    const currentActive = this.activeOrThrow();
+    if (currentActive.RetreatCost == -1) {
       throw new Error("This Pokémon cannot retreat");
     }
     if (
-      previousActive.PrimaryCondition == "Asleep" ||
-      previousActive.PrimaryCondition == "Paralyzed"
+      currentActive.PrimaryCondition == "Asleep" ||
+      currentActive.PrimaryCondition == "Paralyzed"
     ) {
-      throw new Error("Cannot retreat while " + previousActive.PrimaryCondition);
+      throw new Error("Cannot retreat while " + currentActive.PrimaryCondition);
     }
 
-    const previousEnergy = previousActive.AttachedEnergy.slice();
-    const modifiedCost = (previousActive.RetreatCost ?? 0) + costModifier;
+    const previousEnergy = currentActive.AttachedEnergy.slice();
+    const modifiedCost = (currentActive.RetreatCost ?? 0) + costModifier;
 
     if (modifiedCost > previousEnergy.length) {
       throw new Error("Not enough energy to retreat");
@@ -348,24 +366,24 @@ export class Player {
       }
       discardedEnergy.push(previousEnergy.splice(previousEnergy.indexOf(e), 1)[0]);
     }
-    previousActive.AttachedEnergy = previousEnergy;
+    currentActive.AttachedEnergy = previousEnergy;
 
-    this.swapActivePokemon(benchedPokemon, "retreat");
+    this.swapActivePokemon(newActive, "retreat");
     this.discardEnergy(discardedEnergy, "retreat");
   }
 
   swapActivePokemon(
-    pokemon: InPlayPokemonCard,
+    newActive: InPlayPokemonCard,
     reason: "retreat" | "selfEffect" | "opponentEffect",
     choosingPlayer?: string
   ) {
-    const previousActive = this.ActivePokemon!;
-    this.ActivePokemon = pokemon;
-    this.Bench[this.Bench.indexOf(pokemon)] = previousActive;
+    const currentActive = this.activeOrThrow();
+    this.ActivePokemon = newActive;
+    this.Bench[this.Bench.indexOf(newActive)] = currentActive;
 
-    this.logger.swapActivePokemon(this, previousActive, pokemon, reason, choosingPlayer);
+    this.logger.swapActivePokemon(this, currentActive, newActive, reason, choosingPlayer);
 
-    this.recoverAllSpecialConditions(previousActive);
+    this.recoverAllSpecialConditions(currentActive);
   }
 
   recoverAllSpecialConditions(pokemon: InPlayPokemonCard) {
@@ -380,12 +398,17 @@ export class Player {
     this.logger.specialConditionEnded(this, conditions);
   }
 
-  returnPokemonToHand(pokemon: InPlayPokemonCard) {
+  removePokemonFromField(pokemon: InPlayPokemonCard) {
     if (pokemon == this.ActivePokemon) {
-      this.ActivePokemon = undefined;
+      this.ActivePokemon = EmptyCardSlot.Active();
     } else {
-      this.Bench[this.Bench.indexOf(pokemon)] = undefined;
+      const index = this.Bench.indexOf(pokemon);
+      this.Bench[index] = EmptyCardSlot.Bench(index);
     }
+  }
+
+  returnPokemonToHand(pokemon: InPlayPokemonCard) {
+    this.removePokemonFromField(pokemon);
 
     for (const card of pokemon.InPlayCards) {
       this.InPlay.splice(this.InPlay.indexOf(card), 1);
@@ -398,11 +421,7 @@ export class Player {
   }
 
   shufflePokemonIntoDeck(pokemon: InPlayPokemonCard) {
-    if (pokemon == this.ActivePokemon) {
-      this.ActivePokemon = undefined;
-    } else {
-      this.Bench[this.Bench.indexOf(pokemon)] = undefined;
-    }
+    this.removePokemonFromField(pokemon);
 
     for (const card of pokemon.InPlayCards) {
       this.InPlay.splice(this.InPlay.indexOf(card), 1);
@@ -427,11 +446,7 @@ export class Player {
 
     this.discardEnergy(pokemon.AttachedEnergy, "knockOut");
 
-    if (this.ActivePokemon == pokemon) {
-      this.ActivePokemon = undefined;
-    } else {
-      this.Bench[this.Bench.indexOf(pokemon)] = undefined;
-    }
+    this.removePokemonFromField(pokemon);
   }
 
   checkPrizePointsChange(previousPoints: number) {
@@ -450,22 +465,22 @@ export class Player {
   }
 
   poisonActivePokemon() {
-    this.ActivePokemon!.SecondaryConditions.add("Poisoned");
+    this.activeOrThrow().SecondaryConditions.add("Poisoned");
     this.logger.specialConditionApplied(this, "Poisoned");
   }
 
   sleepActivePokemon() {
-    this.ActivePokemon!.PrimaryCondition = "Asleep";
+    this.activeOrThrow().PrimaryCondition = "Asleep";
     this.logger.specialConditionApplied(this, "Asleep");
   }
 
   paralyzeActivePokemon() {
-    this.ActivePokemon!.PrimaryCondition = "Paralyzed";
+    this.activeOrThrow().PrimaryCondition = "Paralyzed";
     this.logger.specialConditionApplied(this, "Paralyzed");
   }
 
   applyActivePokemonStatus(status: PokemonStatus) {
-    this.applyPokemonStatus(this.ActivePokemon!, status);
+    this.applyPokemonStatus(this.activeOrThrow(), status);
   }
 
   applyPokemonStatus(pokemon: InPlayPokemonCard, status: PokemonStatus) {

--- a/src/core/gamelogic/PlayerGameView.ts
+++ b/src/core/gamelogic/PlayerGameView.ts
@@ -187,7 +187,7 @@ export class PlayerGameView {
   async playPokemonToBench(pokemon: PokemonCard, index: number) {
     if (!this.canPlay) return false;
 
-    if (pokemon.Stage == 0 && this.selfBench[index] == undefined) {
+    if (pokemon.Stage == 0 && !this.selfBench[index].isPokemon) {
       await this.#game.delay();
       await this.#game.putPokemonOnBench(pokemon, index);
       return true;

--- a/src/core/gamelogic/PlayerGameView.ts
+++ b/src/core/gamelogic/PlayerGameView.ts
@@ -40,7 +40,10 @@ export class PlayerGameView {
   }
   get canPlay() {
     return (
-      this.isSelfTurn && this.#game.TurnNumber > 0 && this.#game.TurnNumber == this.#turnNumber
+      this.isSelfTurn &&
+      this.#game.TurnNumber > 0 &&
+      this.#game.TurnNumber == this.#turnNumber &&
+      !this.#game.GameOver
     );
   }
 

--- a/src/core/gamelogic/PlayerGameView.ts
+++ b/src/core/gamelogic/PlayerGameView.ts
@@ -223,10 +223,10 @@ export class PlayerGameView {
     await this.#game.delay();
 
     if (!energy) {
-      let retreatCost = this.selfActive!.RetreatCost ?? 0;
+      let retreatCost = this.selfActive.RetreatCost ?? 0;
       retreatCost += this.retreatCostModifier;
       if (retreatCost < 0) retreatCost = 0;
-      energy = this.selfActive!.AttachedEnergy.slice(0, retreatCost);
+      energy = this.selfActive.AttachedEnergy.slice(0, retreatCost);
     }
 
     await this.#game.retreatActivePokemon(benchedPokemon, energy);

--- a/src/core/gamelogic/types/EmptyCardSlot.ts
+++ b/src/core/gamelogic/types/EmptyCardSlot.ts
@@ -1,0 +1,18 @@
+export class EmptyCardSlot {
+  location: "Active" | "Bench";
+  index: number;
+
+  isPokemon = false as const;
+
+  constructor(location: "Active" | "Bench", index: number = -1) {
+    this.location = location;
+    this.index = index;
+  }
+
+  static Active() {
+    return new EmptyCardSlot("Active");
+  }
+  static Bench(index: number) {
+    return new EmptyCardSlot("Bench", index);
+  }
+}

--- a/src/core/gamelogic/types/index.ts
+++ b/src/core/gamelogic/types/index.ts
@@ -1,3 +1,4 @@
+export * from "./EmptyCardSlot";
 export * from "./GameRules";
 export * from "./PlayerAgent";
 export * from "./SpecialCondition";

--- a/src/core/logging/GameLogger.ts
+++ b/src/core/logging/GameLogger.ts
@@ -69,7 +69,7 @@ export class GameLogger {
     this.addEntry({
       type: "selectActivePokemon",
       player: player.Name,
-      toPokemon: player.pokemonToDescriptor(player.ActivePokemon!),
+      toPokemon: player.pokemonToDescriptor(player.activeOrThrow()),
     });
   }
 
@@ -207,8 +207,8 @@ export class GameLogger {
       type: "specialConditionApplied",
       player: player.Name,
       specialConditions: [condition],
-      targetPokemon: player.pokemonToDescriptor(player.ActivePokemon!),
-      currentConditionList: player.ActivePokemon!.CurrentConditions,
+      targetPokemon: player.pokemonToDescriptor(player.activeOrThrow()),
+      currentConditionList: player.activeOrThrow().CurrentConditions,
     });
   }
 
@@ -216,8 +216,8 @@ export class GameLogger {
     this.addEntry({
       type: "specialConditionEffective",
       player: player.Name,
-      targetPokemon: player.pokemonToDescriptor(player.ActivePokemon!),
-      specialCondition: player.ActivePokemon!.PrimaryCondition!,
+      targetPokemon: player.pokemonToDescriptor(player.activeOrThrow()),
+      specialCondition: player.activeOrThrow().PrimaryCondition!,
     });
   }
 
@@ -227,7 +227,7 @@ export class GameLogger {
     initialHP: number,
     damage: number
   ) {
-    const pokemon = player.ActivePokemon!;
+    const pokemon = player.activeOrThrow();
     this.addEntry({
       type: "specialConditionDamage",
       player: player.Name,
@@ -241,7 +241,7 @@ export class GameLogger {
   }
 
   specialConditionEnded(player: Player, conditions: SpecialCondition[]) {
-    const pokemon = player.ActivePokemon!;
+    const pokemon = player.activeOrThrow();
     this.addEntry({
       type: "specialConditionEnded",
       player: player.Name,
@@ -281,7 +281,7 @@ export class GameLogger {
       type: "useAttack",
       player: player.Name,
       attackName,
-      attackingPokemon: player.pokemonToDescriptor(player.ActivePokemon!),
+      attackingPokemon: player.pokemonToDescriptor(player.activeOrThrow()),
     });
   }
 
@@ -317,7 +317,7 @@ export class GameLogger {
       type: "copyAttack",
       player: player.Name,
       attackName,
-      attackingPokemon: player.pokemonToDescriptor(player.ActivePokemon!),
+      attackingPokemon: player.pokemonToDescriptor(player.activeOrThrow()),
     });
   }
 

--- a/src/core/parsing/parseAbility.ts
+++ b/src/core/parsing/parseAbility.ts
@@ -63,7 +63,7 @@ export const parseAbility = (inputAbility: InputCardAbility): ParsedResult<Abili
         const pt = parseEnergy(pokemonType);
 
         ability.Effect = async (game: Game) => {
-          const pokemon = game.AttackingPlayer.ActivePokemon!;
+          const pokemon = game.AttackingPlayer.activeOrThrow();
           if (pokemon.Type != pt) {
             game.GameLog.noValidTargets(game.AttackingPlayer);
             return;

--- a/src/core/parsing/parseAttackEffect.ts
+++ b/src/core/parsing/parseAttackEffect.ts
@@ -155,7 +155,7 @@ export const parseAttackEffect = (
         /^This attack does (\d+) more damage for each Energy attached to your opponent's Active Pokémon\.$/i,
       transform: (_, extraDamage) => async (game: Game) => {
         const energyCount = game.DefendingPlayer.activeOrThrow().AttachedEnergy.length;
-        const damage = baseAttackHP! + Number(extraDamage) * energyCount;
+        const damage = baseAttackHP + Number(extraDamage) * energyCount;
         game.attackActivePokemon(damage);
       },
     },

--- a/src/core/parsing/parseAttackEffect.ts
+++ b/src/core/parsing/parseAttackEffect.ts
@@ -71,7 +71,7 @@ export const parseAttackEffect = (
         const conditionalEffect = recursiveParse(effectText);
 
         return async (game: Game) => {
-          const active = game.AttackingPlayer.ActivePokemon!;
+          const active = game.AttackingPlayer.activeOrThrow();
           if (active.hasSufficientEnergy(secondaryRequiredEnergy)) await conditionalEffect(game);
           else await defaultEffect(game);
         };
@@ -83,7 +83,7 @@ export const parseAttackEffect = (
         const conditionalEffect = recursiveParse(effectText);
 
         return async (game: Game) => {
-          const active = game.DefendingPlayer.ActivePokemon!;
+          const active = game.DefendingPlayer.activeOrThrow();
           // TODO: need to implement a separate "MaxHP" property for capes
           if (active.CurrentHP < active.BaseHP) await conditionalEffect(game);
           else await defaultEffect(game);
@@ -96,7 +96,7 @@ export const parseAttackEffect = (
         const conditionalEffect = recursiveParse(effectText);
 
         return async (game: Game) => {
-          const active = game.AttackingPlayer.ActivePokemon!;
+          const active = game.AttackingPlayer.activeOrThrow();
           if (active.CurrentHP < active.BaseHP) await conditionalEffect(game);
           else await defaultEffect(game);
         };
@@ -108,7 +108,7 @@ export const parseAttackEffect = (
         const conditionalEffect = recursiveParse(effectText);
 
         return async (game: Game) => {
-          const defender = game.DefendingPlayer.ActivePokemon!;
+          const defender = game.DefendingPlayer.activeOrThrow();
           if (defender.SecondaryConditions.has("Poisoned")) await conditionalEffect(game);
           else await defaultEffect(game);
         };
@@ -143,7 +143,7 @@ export const parseAttackEffect = (
         const predicate = fullType ? (e: Energy) => e == fullType : () => true;
 
         return async (game: Game) => {
-          const energy = game.AttackingPlayer.ActivePokemon!.AttachedEnergy;
+          const energy = game.AttackingPlayer.activeOrThrow().AttachedEnergy;
           const totalFlips = energy.filter(predicate).length;
           const { heads } = game.AttackingPlayer.flipMultiCoins(totalFlips);
           game.attackActivePokemon(heads * Number(damage));
@@ -154,7 +154,7 @@ export const parseAttackEffect = (
       pattern:
         /^This attack does (\d+) more damage for each Energy attached to your opponent's Active Pokémon\.$/i,
       transform: (_, extraDamage) => async (game: Game) => {
-        const energyCount = game.DefendingPlayer.ActivePokemon!.AttachedEnergy.length;
+        const energyCount = game.DefendingPlayer.activeOrThrow().AttachedEnergy.length;
         const damage = baseAttackHP! + Number(extraDamage) * energyCount;
         game.attackActivePokemon(damage);
       },
@@ -231,7 +231,7 @@ export const parseAttackEffect = (
       pattern: /^This Pokémon also does (\d+) damage to itself\.$/i,
       transform: (_, selfDamage) => async (game: Game) => {
         await defaultEffect(game);
-        game.applyDamage(game.AttackingPlayer.ActivePokemon!, Number(selfDamage), true);
+        game.applyDamage(game.AttackingPlayer.activeOrThrow(), Number(selfDamage), true);
       },
     },
     {
@@ -253,7 +253,7 @@ export const parseAttackEffect = (
       pattern: /^Heal (\d+) damage from this Pokémon\.$/,
       transform: (_, HP) => async (game: Game) => {
         await defaultEffect(game);
-        game.healPokemon(game.AttackingPlayer.ActivePokemon!, Number(HP));
+        game.healPokemon(game.AttackingPlayer.activeOrThrow(), Number(HP));
       },
     },
     {
@@ -261,7 +261,7 @@ export const parseAttackEffect = (
         /^Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon\.$/i,
       transform: () => async (game: Game) => {
         const damageDealt = game.attackActivePokemon(baseAttackHP);
-        game.healPokemon(game.AttackingPlayer.ActivePokemon!, damageDealt);
+        game.healPokemon(game.AttackingPlayer.activeOrThrow(), damageDealt);
       },
     },
 
@@ -311,7 +311,7 @@ export const parseAttackEffect = (
 
         return async (game: Game) => {
           await defaultEffect(game);
-          game.discardEnergy(game.AttackingPlayer.ActivePokemon!, fullType, Number(count) || 1);
+          game.discardEnergy(game.AttackingPlayer.activeOrThrow(), fullType, Number(count) || 1);
         };
       },
     },
@@ -319,14 +319,14 @@ export const parseAttackEffect = (
       pattern: /^Discard all Energy from this Pokémon\.$/i,
       transform: () => async (game: Game) => {
         await defaultEffect(game);
-        game.discardAllEnergy(game.AttackingPlayer.ActivePokemon!);
+        game.discardAllEnergy(game.AttackingPlayer.activeOrThrow());
       },
     },
     {
       pattern: /^Discard a random Energy from your opponent's Active Pokémon.$/i,
       transform: () => async (game: Game) => {
         await defaultEffect(game);
-        game.DefendingPlayer.discardRandomEnergy(game.DefendingPlayer.ActivePokemon!);
+        game.DefendingPlayer.discardRandomEnergy(game.DefendingPlayer.activeOrThrow());
       },
     },
     {
@@ -338,7 +338,7 @@ export const parseAttackEffect = (
         return async (game: Game) => {
           await defaultEffect(game);
           game.AttackingPlayer.attachEnergy(
-            game.AttackingPlayer.ActivePokemon!,
+            game.AttackingPlayer.activeOrThrow(),
             new Array(count == "a" ? 1 : Number(count)).fill(fullType),
             "energyZone"
           );
@@ -384,7 +384,7 @@ export const parseAttackEffect = (
       pattern: /^your opponent shuffles their Active Pokémon back into their deck\./i,
       transform: () => async (game: Game) => {
         await defaultEffect(game);
-        game.DefendingPlayer.shufflePokemonIntoDeck(game.DefendingPlayer.ActivePokemon!);
+        game.DefendingPlayer.shufflePokemonIntoDeck(game.DefendingPlayer.activeOrThrow());
       },
     },
 
@@ -475,7 +475,7 @@ export const parseAttackEffect = (
         }
         game.GameLog.copyAttack(game.AttackingPlayer, chosenAttack.Name);
         if (
-          game.AttackingPlayer.ActivePokemon!.hasSufficientEnergy(chosenAttack.RequiredEnergy) &&
+          game.AttackingPlayer.activeOrThrow().hasSufficientEnergy(chosenAttack.RequiredEnergy) &&
           !chosenAttack.Text?.includes("use it as this attack")
         ) {
           await game.useEffect(chosenAttack.Effect);

--- a/src/core/parsing/parseTrainerEffect.ts
+++ b/src/core/parsing/parseTrainerEffect.ts
@@ -102,7 +102,7 @@ export const parseTrainerEffect = (cardText: string): ParsedResult<Effect> => {
 
         return async (game: Game) => {
           const active = game.AttackingPlayer.ActivePokemon;
-          if (active && names.includes(active.Name)) {
+          if (active.isPokemon && names.includes(active.Name)) {
             game.AttackingPlayer.returnPokemonToHand(active);
           } else {
             game.GameLog.noValidTargets(game.AttackingPlayer);
@@ -139,17 +139,16 @@ export const parseTrainerEffect = (cardText: string): ParsedResult<Effect> => {
         const names = parsePokemonNames(pokemonNames);
 
         return async (game: Game) => {
-          if (!names.includes(game.AttackingPlayer.ActivePokemon!.Name)) {
+          if (!names.includes(game.AttackingPlayer.activeOrThrow().Name)) {
             game.GameLog.noValidTargets(game.AttackingPlayer);
             return;
           }
-          for (const pokemon of game.AttackingPlayer.Bench) {
-            if (!pokemon) continue;
+          for (const pokemon of game.AttackingPlayer.BenchedPokemon) {
             const energyToMove = pokemon.AttachedEnergy.filter((e) => e == fullType);
             if (energyToMove.length > 0) {
               game.AttackingPlayer.transferEnergy(
                 pokemon,
-                game.AttackingPlayer.ActivePokemon!,
+                game.AttackingPlayer.activeOrThrow(),
                 energyToMove
               );
             }


### PR DESCRIPTION
The new class takes the place of `undefined` in the Active Spot and on the Bench. This will eventually allow for a proper selection of an empty Bench slot by player agents.

Also fixed an old bug that was causing occasional errors with the Articuno ex deck after game over. (Specifically, when Greninja knocked out the Active Pokemon to win the game, the agent was still attempting to attack. Actions after game over have now been disabled.)